### PR TITLE
Add a few missing config options 

### DIFF
--- a/src/general.md
+++ b/src/general.md
@@ -54,6 +54,8 @@ Overrides allow you to customize which levels and roles can use each command, or
 "plugin.name" is used for all commands in a plugin (hint: every section that's indented one in beneath the "plugins:" section is a plugin)  
 "group" is used for commands which have multiple components. Some examples: clean, archive, role, stars)  
 "name" is used for all other commands.  
-"out: {level: }}" is used to assign the minimum level required to use the command.
+"out: {level: }}" is used to assign the minimum level required to use the command
+"out: {disabled: true}}" is used to disable commands
+
 
 Taking the configuration above as an example, if you didn't want regular members to use utility commands (such as jumbo, info, and cat), you can set the level of the "utilities" plugin to 10. This means the role must have at least level 10 assigned to use utility commands.

--- a/src/plugins/admin.md
+++ b/src/plugins/admin.md
@@ -37,6 +37,7 @@ The admin plugin provides a set of administrator commands that help in moderatin
 | group\_roles | Roles which can be joined and left by any user. These roles cannot grant any elevated permissions | dict | empty |
 | locked\_roles | Prevents permission changes from being made to listed roles | list | empty |
 | persist | Controls the member persistance settings | dict | empty |
+| group_confirm_reactions | Whether to confirm via reaction when users join a role | bool | false |
 
 ### Member Persistance Settings
 
@@ -60,6 +61,7 @@ The admin plugin provides a set of administrator commands that help in moderatin
     role_aliases:
       role1: 205769314199011329
       role2: 333806119199703042
+    group_confirm_reactions: true
     group_roles:
       PC: 278810978722906112
       Console: 278972377587515392

--- a/src/plugins/infractions.md
+++ b/src/plugins/infractions.md
@@ -21,7 +21,7 @@ The infractions plugin provides a set of useful moderator commands. These comman
 | `!infractions search {query}` | Searches infractions database for given query | Moderator | `!infractions search 232921983317180416` OR `!infractions search rowboat#0001` OR `!infractions search spamming`
 | `!infractions info {inf#}` | Presents information on the given infraction | Moderator | `!infractions info 1274`
 | `!infractions duration {inf#} {duration}` | Updates the duration of the given infraction. Duration starts from time of initial action | Moderator | `!infractions duration 1274 5h` |
-| `!reason {inf#} {reason}` | Updates the reason of a given infraction | Moderator | `!infractions reason 1274 rude behaviour towards staff` |
+| `!infractions reason {inf#} {reason}` | Updates the reason of a given infraction | Moderator | `!infractions reason 1274 rude behaviour towards staff` |
 
 ## Configuration Options
 

--- a/src/plugins/starboard.md
+++ b/src/plugins/starboard.md
@@ -33,6 +33,7 @@ The starboard plugin provides an ongoing board of highlighted messages through c
 | min\_stars | Minimum number of star reactions required before a message is posted to the starboard | int | 1 |
 | star\_color\_max | Sets the "max" star level. Changes shading of rich embed bar color per level and gives the starboard entry a different emoji at max level | int | 15 |
 | prevent\_self\_star | Whether to prevent a user from starring their own message | bool | false |
+| ignored\_channels | Sets which channels to ignore starred messages from | dict | empty |
 
 ## Configuration Example
 
@@ -44,4 +45,5 @@ The starboard plugin provides an ongoing board of highlighted messages through c
         min_stars: 6
         star_color_max: 15
         prevent_self_star: true
+        ignored_channels: []
 ```


### PR DESCRIPTION
Just adding a few config options which are missing from the docs.

There are a few more missing, but they don't seem to be implemented yet, so I ignored them.

Mind the **reason** fix, I don't know if in the hosted version of rowboat it is still grouped under "Infractions". If this is not the case, ignore that commit I suppose.